### PR TITLE
chore: only run auto-merge action if PR is not yet approved

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -7,7 +7,9 @@ jobs:
   auto-merge:
     name: Auto-merge dependabot PRs for minor and patch updates
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'dependencies')
+    if: |
+      contains( github.event.pull_request.labels.*.name, 'dependencies' )
+      && ! contains( github.event.pull_request.labels.*.name, '[Status] Approved' )
     steps:
       - uses: actions/checkout@v2
       - uses: ahmadnassri/action-dependabot-auto-merge@v2


### PR DESCRIPTION
Implements the same fix for the same reason as https://github.com/Automattic/newspack-plugin/pull/1372. Easier to test here since there are open Dependabot PRs.