### PR TITLE
Add hotfix flow; update post-release script

### DIFF
--- a/post-release.sh
+++ b/post-release.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# This script should be ran on CI after a new regular (not pre-release) version is released.
+
 git config user.name "$GIT_COMMITTER_NAME"
 git config user.email "$GITHUB_COMMITER_EMAIL"
 

--- a/post-release.sh
+++ b/post-release.sh
@@ -11,7 +11,7 @@ SECOND_TO_LAST_COMMIT_MSG=$(git log -n 1 --skip 1 --pretty=format:"%s")
 
 LATEST_VERSION_TAG=$(git describe --tags --abbrev=0)
 
-# If the merge was from alpha branch, alpha branch should be reset.
+# If the merge was from alpha branch (the basic flow), alpha branch should be reset.
 if [[ $(echo $SECOND_TO_LAST_COMMIT_MSG | grep '^Merge .*alpha') ]]; then
   echo '[newspack-scripts] Release was created from the alpha branch. Alpha branch will now be reset.'
 
@@ -23,6 +23,12 @@ if [[ $(echo $SECOND_TO_LAST_COMMIT_MSG | grep '^Merge .*alpha') ]]; then
   git reset --hard release --
   # Force-push the alpha branch.
   git push "https://$GITHUB_TOKEN@github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git" --force
+else
+  echo '[newspack-scripts] Release was created from a different branch than the alpha branch (e.g. a hotfix branch).'
+  echo '[newspack-scripts] Alpha branch will now be updated with the lastest changes from release.'
+  git checkout alpha
+  git merge release --strategy-option=theirs --message="Merge release into alpha"
+  git push "https://$GITHUB_TOKEN@github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git"
 fi
 
 # Update master branch with latest changes from the release branch, so they are in sync.

--- a/post-release.sh
+++ b/post-release.sh
@@ -27,6 +27,6 @@ fi
 echo '[newspack-scripts] Merging the release branch into master'
 git checkout master
 git merge --squash release
-git commit --message "chore(release): merge in release $LATEST_VERSION_TAG [skip ci]"
+git commit --message "chore(release): merge in release $LATEST_VERSION_TAG"
 # Push updated master upstream.
 git push "https://$GITHUB_TOKEN@github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git"

--- a/post-release.sh
+++ b/post-release.sh
@@ -10,7 +10,7 @@ SECOND_TO_LAST_COMMIT_MSG=$(git log -n 1 --skip 1 --pretty=format:"%s")
 LATEST_VERSION_TAG=$(git describe --tags --abbrev=0)
 
 # If the merge was from alpha branch, alpha branch should be reset.
-if [[ $(echo $SECOND_TO_LAST_COMMIT_MSG | grep '^Merge pull request.*alpha') ]]; then
+if [[ $(echo $SECOND_TO_LAST_COMMIT_MSG | grep '^Merge .*alpha') ]]; then
   echo '[newspack-scripts] Release was created from the alpha branch. Alpha branch will now be reset.'
 
   # Reset the tip of alpha branch to the release branch.

--- a/post-release.sh
+++ b/post-release.sh
@@ -26,7 +26,8 @@ fi
 # Update master branch with latest changes from the release branch, so they are in sync.
 echo '[newspack-scripts] Merging the release branch into master'
 git checkout master
-git merge --squash release
+# Merge release branch into master branch, prefering the changes from release branch if conflicts arise.
+git merge --squash release --strategy-option=theirs
 git commit --message "chore(release): merge in release $LATEST_VERSION_TAG"
 # Push updated master upstream.
 git push "https://$GITHUB_TOKEN@github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git"

--- a/post-release.sh
+++ b/post-release.sh
@@ -3,19 +3,30 @@
 git config user.name "$GIT_COMMITTER_NAME"
 git config user.email "$GITHUB_COMMITER_EMAIL"
 
-# Reset the tip of alpha branch to the release branch.
-# The alpha brach is single-serving, just for alpha releases. After a release,
-# we don't care about any alpha changes.
-git pull origin release
-git checkout alpha
-git reset --hard release --
-git push "https://$GITHUB_TOKEN@github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git" --force
+# The last commit message at this point is the automated release commit. The second-to-last
+# commit message should contain data about the merge.
+SECOND_TO_LAST_COMMIT_MSG=$(git log -n 1 --skip 1 --pretty=format:"%s")
 
-# Cherry-pick the latest commit from the release branch onto the master branch.
-# This way the version numbers and the changelog on master are up to date.
-#
-# Note that this will fail if there is no CHANGELOG.md on master - in such case the cherry-pick will
-# result in a conflict.
+LATEST_VERSION_TAG=$(git describe --tags --abbrev=0)
+
+# If the merge was from alpha branch, alpha branch should be reset.
+if [[ $(echo $SECOND_TO_LAST_COMMIT_MSG | grep '^Merge pull request.*alpha') ]]; then
+  echo '[newspack-scripts] Release was created from the alpha branch. Alpha branch will now be reset.'
+
+  # Reset the tip of alpha branch to the release branch.
+  # The alpha brach is single-serving, just for alpha releases. After a release,
+  # we don't care about any alpha changes.
+  git pull origin release
+  git checkout alpha
+  git reset --hard release --
+  # Force-push the alpha branch.
+  git push "https://$GITHUB_TOKEN@github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git" --force
+fi
+
+# Update master branch with latest changes from the release branch, so they are in sync.
+echo '[newspack-scripts] Merging the release branch into master'
 git checkout master
-git cherry-pick $(git rev-parse release) --strategy-option theirs
+git merge --squash release
+git commit --message "chore(release): merge in release $LATEST_VERSION_TAG [skip ci]"
+# Push updated master upstream.
 git push "https://$GITHUB_TOKEN@github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git"

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -19,10 +19,17 @@ const config = {
   debug: semanticReleaseArgs.debug,
 
   branches: [
+    // `release` branch is published on the main distribution channel (a new version on GH).
     "release",
+    // `alpha` branch – for regular pre-releases.
     {
       name: "alpha",
       prerelease: "alpha",
+    },
+    // `hotfix/*` branches – for releases outside of the release schedule.
+    {
+      name: "hotfix/*",
+      prerelease: "hotfix",
     },
   ],
   prepare: [


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

1. Updates `semantic-release` configuration to handle `hotfix/*` branches
2. Updates the post-release script – instead of cherry-picking the generated commit (with version number changes etc.) from the `release` branch to `master` branch, `release` branch is merged into `master`. This is a breaking change, and is meant to facilitate the hotfix workflow, in which `hotfix/*` branches are created off the `release` branch.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
