### PR TITLE
feat: allow hotfix-type commits to trigger a release

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -50,8 +50,15 @@ const config = {
     },
   ],
   plugins: [
-    "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/commit-analyzer", {
+        "releaseRules": [
+          { "type": "hotfix", "release": "patch" },
+          { "type": "style", "release": "patch" }
+        ]
+      }
+    ],
     [
       // Do not publish on npm.
       "@semantic-release/npm",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Commits with a `hotfix:` prefix correctly trigger a semantic version number patch bump, but do not trigger a release. This is because the [default `commit-analyzer` config](https://github.com/semantic-release/commit-analyzer/blob/master/lib/default-release-rules.js) doesn't include a rule to handle `hotfix:` commits. This PR adds rules for `hotfix:` and `style:` commits. This means that any branch merged into `release` that contains only `hotfix:` or `style:` type commits will trigger patch releases.

### How to test the changes in this Pull Request:

Can't really test that this will work until the next hotfix. But you can test that the config is well-formed by running `npm run semantic-version` locally to trigger a dry run.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
