### PR TITLE
fix: do not squash post-release merges

### DIFF
--- a/post-release.sh
+++ b/post-release.sh
@@ -35,7 +35,7 @@ fi
 echo '[newspack-scripts] Merging the release branch into master'
 git checkout master
 # Merge release branch into master branch, prefering the changes from release branch if conflicts arise.
-git merge --squash release --strategy-option=theirs
+git merge release --strategy-option=theirs
 git commit --message "chore(release): merge in release $LATEST_VERSION_TAG"
 # Push updated master upstream.
 git push "https://$GITHUB_TOKEN@github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git"

--- a/post-release.sh
+++ b/post-release.sh
@@ -35,7 +35,6 @@ fi
 echo '[newspack-scripts] Merging the release branch into master'
 git checkout master
 # Merge release branch into master branch, prefering the changes from release branch if conflicts arise.
-git merge release --strategy-option=theirs
-git commit --message "chore(release): merge in release $LATEST_VERSION_TAG"
+git merge --no-ff release --strategy-option=theirs -m "chore(release): merge in release $LATEST_VERSION_TAG"
 # Push updated master upstream.
 git push "https://$GITHUB_TOKEN@github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Avoids squashing the merges from `release` back into `master`, so that `master` retains the full commit history for hotfixes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
