### PR TITLE
test: upgrade wp version

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -1,10 +1,10 @@
 description: >
   This is a sample executor using Docker and Node.
 docker:
-  - image: 'cimg/php:<<parameters.tag>>'
+  - image: "cimg/php:<<parameters.tag>>"
 parameters:
   tag:
-    default: 7.4-browsers
+    default: 8.0-browsers
     description: >
       Pick a specific circleci/php image variant:
       https://hub.docker.com/r/cimg/php/tags

--- a/src/jobs/test-php.yml
+++ b/src/jobs/test-php.yml
@@ -22,7 +22,7 @@ steps:
   - run:
       name: Run Tests
       command: |
-        composer install
+        composer update
         rm -rf $WP_TESTS_DIR $WP_CORE_DIR
         bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
         ./vendor/bin/phpunit

--- a/src/jobs/test-php.yml
+++ b/src/jobs/test-php.yml
@@ -23,7 +23,6 @@ steps:
       name: Run Tests
       command: |
         composer install
-        composer global require "phpunit/phpunit=7.5.*"
         rm -rf $WP_TESTS_DIR $WP_CORE_DIR
-        bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 5.8.1
-        phpunit
+        bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
+        ./vendor/bin/phpunit

--- a/src/jobs/test-php.yml
+++ b/src/jobs/test-php.yml
@@ -2,12 +2,12 @@ description: >
   Run PHP tests.
 
 docker:
-  - image: cimg/php:7.4
+  - image: cimg/php:8.0
   - image: circleci/mysql:5.6.50
 
 environment:
-  - WP_TESTS_DIR: '/tmp/wordpress-tests-lib'
-  - WP_CORE_DIR: '/tmp/wordpress/'
+  - WP_TESTS_DIR: "/tmp/wordpress-tests-lib"
+  - WP_CORE_DIR: "/tmp/wordpress/"
 steps:
   - checkout
   - run:


### PR DESCRIPTION
Also use local version of phpunit

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

* Updates the WP version used in tests to the latest, now that we have updated our dependencies
* Use the local copy of phpunit, now that all projects explicitly require the right version
* Uses composer update instead of install so we can run the tests both in php 7.4 and 8. When we finish upgrading all repos we can set up tests for both version and use `update` only for php 7.4

See pamTN9-5eU-p2

### How to test the changes in this Pull Request:

1. Publish the CI Orb as a development version (e.g. `circleci orb pack src/ > orb.yml && circleci orb publish orb.yml adekbadek/newspack@dev:wp-version-tests`)
2. Use this Orb version on a branch, to trigger CI (e.g. https://github.com/Automattic/newspack-plugin/pull/2023/commits/0c4413ff2ed25c1be713bbbffa10e8ced870cb13)
3. Observe the PHP CI jobs passing, using latest WP and PHP `8.0.0` (e.g. https://app.circleci.com/pipelines/github/Automattic/newspack-plugin/5191/workflows/234da34f-96f4-403f-b0e9-4b2528320ddf)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->