### PR TITLE
feat(release): commit changelog and npm files on release branch only

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,11 @@ circleci orb pack src/ > orb.yml && circleci orb publish orb.yml newspack/newspa
 
 Note that before the first time updating you'll need to set the API key for CircleCI CLI by running `$ circleci setup`.
 
+### Testing locally
+
+1. Copy the path to this repository (e.g. `pwd | pbcopy`) and "install" it as an npm dependency in the repository on which you wish to test (e.g. `npm i /path/to/newspack-scripts`). You should end up with a `"newspack-scripts": "file:*"` entry in `package.json` instead of a version number.
+2. Trigger a script and observe the results, e.g. `npm run semantic-release -- --dry-run`
+
 ---
 
 ## Misc

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -87,24 +87,32 @@ const getConfig = ({ gitBranchName }) => {
   ]);
 
   // Unless on a hotfix or epic branch, add a commit that updates the files.
-  if (gitBranchName.indexOf("hotfix/") !== 0 && gitBranchName.indexOf("epic/") !== 0) {
-    utils.log(`Plugin files and the changelog will be updated.`);
-    config.prepare.push({
-      path: "@semantic-release/git",
-      // These assets should be added to source control after a release.
-      assets: [
+  const branchType = gitBranchName.split("/")[0];
+  if (["hotfix", "epic"].indexOf(branchType) === -1) {
+    let assets = filesList;
+    // These assets should be added to source control after a release.
+    if (branchType === "release") {
+      assets = [
         ...filesList,
         "package.json",
         "package-lock.json",
         "CHANGELOG.md",
-      ],
+      ];
+    }
+    utils.log(
+      `On ${branchType} branch, following files will be updated: ${assets.join(
+        ", "
+      )}`
+    );
+    config.prepare.push({
+      path: "@semantic-release/git",
+      assets,
       message:
         "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
     });
   } else {
-    const branchType = gitBranchName.indexOf("hotfix/") === 0 ? 'hotfix' : 'epic';
     utils.log(
-      `This is a ${branchType} branch, plugin files and the changelog will *not* be updated.`
+      `This branch is ${branchType}, plugin files and the changelog will *not* be updated.`
     );
   }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Updates the release script so that `package.json`, `package-lock.json`, and `CHANGELOG.md` are not updated when releasing to a channel other than `release`. Committing these files on `alpha` release channel generates noise in the changelog (and is not needed there), and creates merge conflicts.

### How to test the changes in this Pull Request:

Test according to "Testing locally" instructions in the README

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->