### PR TITLE
fix: successComment value in @semantic-release/github config

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -22,6 +22,20 @@ if (shouldPublishOnNPM) {
 
 const getConfig = ({ gitBranchName }) => {
   const branchType = gitBranchName.split("/")[0];
+  const githubConfig = {
+    assets: [
+      {
+        path: `./release/${process.env.CIRCLE_PROJECT_REPONAME}.zip`,
+        label: `${process.env.CIRCLE_PROJECT_REPONAME}.zip`,
+      },
+    ],
+  };
+
+  // Only post GH PR comments for alpha, hotfix/*, and release branches.
+  if ( ! ["alpha", "hotfix", "release"].includes(branchType) ) {
+    githubConfig.successComment = false;
+	githubConfig.failComment = false;
+  }
 
   const config = {
     dryRun: otherArgs.dryRun,
@@ -66,16 +80,7 @@ const getConfig = ({ gitBranchName }) => {
       // Add the built ZIP archive to GH release.
       [
         "@semantic-release/github",
-        {
-          assets: [
-            {
-              path: `./release/${process.env.CIRCLE_PROJECT_REPONAME}.zip`,
-              label: `${process.env.CIRCLE_PROJECT_REPONAME}.zip`,
-            },
-          ],
-          // Only post GH PR comments for alpha, hotfix/*, and release branches.
-          successComment: ["alpha", "hotfix", "release"].includes(branchType),
-        },
+        githubConfig,
       ],
     ],
   };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes blocking errors in the `release` script ([example](https://app.circleci.com/pipelines/github/Automattic/newspack-blocks/4187/workflows/446abd58-aca0-49c5-8a9a-3bd82021a14a/jobs/17899)):

```sh
[11:18:42 PM] [semantic-release] › ✖  Failed step "fail" of plugin "@semantic-release/github"
[11:18:42 PM] [semantic-release] › ✖  EINVALIDSUCCESSCOMMENT Invalid `successComment` option.
The successComment option (https://github.com/semantic-release/github/blob/master/README.md#successcomment) if defined, must be a non empty String.

Your configuration for the successComment option is true.

[11:18:42 PM] [semantic-release] › ✖  EINVALIDSUCCESSCOMMENT Invalid `successComment` option.
The successComment option (https://github.com/semantic-release/github/blob/master/README.md#successcomment) if defined, must be a non empty String.

Your configuration for the successComment option is true.

The automated release failed with AggregateError: 
    SemanticReleaseError: Invalid `successComment` option.
        at module.exports (/home/circleci/project/node_modules/@semantic-release/github/lib/get-error.js:6:10)
        at /home/circleci/project/node_modules/@semantic-release/github/lib/verify.js:43:23
        at Array.reduce (<anonymous>)
        at module.exports (/home/circleci/project/node_modules/@semantic-release/github/lib/verify.js:40:54)
        at verifyConditions (/home/circleci/project/node_modules/@semantic-release/github/index.js:27:9)
        at validator (/home/circleci/project/node_modules/semantic-release/lib/plugins/normalize.js:34:30)
        at /home/circleci/project/node_modules/semantic-release/lib/plugins/pipeline.js:37:40
        at next (/home/circleci/project/node_modules/p-reduce/index.js:17:9)
        at runMicrotasks (<anonymous>)
        at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at /home/circleci/project/node_modules/semantic-release/lib/plugins/pipeline.js:54:11
    at async Object.pluginsConf.<computed> [as verifyConditions] (/home/circleci/project/node_modules/semantic-release/lib/plugins/index.js:80:11)
    at async run (/home/circleci/project/node_modules/semantic-release/index.js:103:3)
    at async module.exports (/home/circleci/project/node_modules/semantic-release/index.js:269:22)
    at async run (/home/circleci/project/node_modules/newspack-scripts/scripts/release.js:129:20)
```

In the current release, `successComment` evals to `true` if the base branch is a  `release`, `alpha`, or `hotfix` branch. `true` isn't a valid value for this option in the [`@semantic-release/github` plugin](https://github.com/semantic-release/github/)—if we want the default commenting behavior, we should simply omit the option from the config object.

This patch only assigns `successComment` a value of `false` (meaning we don't want `@semantic-release` to post a comment to the PR) if the base branch isn't a `release`, `alpha`, or `hotfix` branch. If the base branch IS one of these, omitting `successComment` from the config should result in `@semantic-release` posting a default success message to the PR.

### How to test the changes in this Pull Request:

Can't think of a way to test this without letting it fly..

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
