### PR TITLE
feat(lint-js): use prettier in eslint; adjust prettier config

### DIFF
--- a/config/eslintrc.js
+++ b/config/eslintrc.js
@@ -1,5 +1,9 @@
-const wpRecommended = require.resolve( '@wordpress/eslint-plugin/configs/recommended' );
-const reactRecommended = require.resolve( '@wordpress/eslint-plugin/configs/react' );
+const wpRecommended = require.resolve(
+	'@wordpress/eslint-plugin/configs/recommended'
+);
+const reactRecommended = require.resolve(
+	'@wordpress/eslint-plugin/configs/react'
+);
 
 /**
  *  Assume `@wordpress/*` packages are available. This is because `@wordpress/scripts` is using
@@ -37,7 +41,13 @@ module.exports = {
 			},
 		},
 	},
-	ignorePatterns: [ 'dist/', 'node_modules/', 'release/', 'scripts/', '/vendor' ],
+	ignorePatterns: [
+		'dist/',
+		'node_modules/',
+		'release/',
+		'scripts/',
+		'/vendor',
+	],
 	rules: {
 		'arrow-parens': 'off',
 		camelcase: 'off',
@@ -49,7 +59,10 @@ module.exports = {
 		// See https://github.com/WordPress/gutenberg/blob/e035f71/packages/dependency-extraction-webpack-plugin/README.md#behavior-with-scripts
 		// Unfortunately there's no "ignore" option for this rule, so it's disabled altogether.
 		'import/no-extraneous-dependencies': 'off',
-		'import/no-unresolved': [ 'error', { ignore: GLOBALLY_AVAILABLE_PACKAGES } ],
+		'import/no-unresolved': [
+			'error',
+			{ ignore: GLOBALLY_AVAILABLE_PACKAGES },
+		],
 		'import/namespace': 'off',
 		// There's a conflict with prettier here:
 		'react/jsx-curly-spacing': 'off',
@@ -72,6 +85,5 @@ module.exports = {
 		'@typescript-eslint/no-shadow': 'error',
 		'@typescript-eslint/ban-ts-comment': 'warn',
 		'@typescript-eslint/no-explicit-any': 'warn',
-		'prettier/prettier': 'off', // We're mainly concerned about code quality rules, not formatting. npm run format:js can be used to reformat JS if desired.
 	},
 };

--- a/config/prettier.config.js
+++ b/config/prettier.config.js
@@ -3,4 +3,5 @@ const wpConfig = require( '@wordpress/prettier-config' );
 module.exports = {
 	...wpConfig,
 	arrowParens: 'avoid',
+	printWidth: 150,
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Reestablishes using `prettier` in eslint config, and adjusts the prettier config to allow for longer line-width.

### How to test the changes in this Pull Request:

1. In a repository which uses `newspack-scripts`, either install `newspack-scripts` as a local package, or just replace the two files from this PR in `node_modules/newspack-scripts/` 
2. Run `npm run lint:js` and observe `prettier` rule errors 
3. Fixing these is a matter of PRs in the other repositories 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->