### PR TITLE
fix: exit process with test script's exit code [NPPM-2038]

### DIFF
--- a/scripts/test.js
+++ b/scripts/test.js
@@ -45,8 +45,10 @@ const JEST_CONFIG = {
 
 args.push( '--config', JSON.stringify( JEST_CONFIG ) );
 
-spawn.sync( wpScripts, args, {
+const result = spawn.sync( wpScripts, args, {
 	cwd: modules.rootDirectory,
 	stdio: 'inherit',
 	env: { ...process.env, NODE_ENV: 'development' },
 } );
+
+process.exit(result.status);


### PR DESCRIPTION
We had some CI tests that were failing, but the job still marked them as successfully run. 

This reports the process status as an exit code.

### How to test the changes in this Pull Request:
1. Run `npm run test` (I tested on newspack-plugin which is currently failing)
2. Run `echo $?` and see that it is `0` without the patch and `1` with.
