### PR TITLE
ci(orb): add i18n

### DIFF
--- a/src/jobs/i18n.yml
+++ b/src/jobs/i18n.yml
@@ -1,0 +1,73 @@
+description: >
+  Create translation files.
+
+executor: default
+
+steps:
+  - checkout_with_workspace
+  - run:
+      name: Check if commit author is bot
+      command: |
+        COMMIT_AUTHOR=$(git log -1 --pretty=format:'%ae')
+        if [ "$COMMIT_AUTHOR" = "$GITHUB_COMMITER_EMAIL" ]; then
+          echo "Commit was made by bot ($(git rev-parse --short HEAD)), skipping translation update"
+          circleci step halt
+        fi
+  - run:
+      name: Install WP CLI
+      command: |
+        curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+        chmod +x wp-cli.phar
+        sudo mv wp-cli.phar /usr/local/bin/wp
+  - run:
+      name: Build plugin files, so dist dir is available
+      command: |
+        npm run build || true
+  - run:
+      name: Create POT translation files
+      command: |
+        # Theme is excluded, more in https://github.com/Automattic/newspack-theme/pull/2458
+        if [ "$CIRCLE_PROJECT_REPONAME" = "newspack-theme" ]; then
+          wp i18n make-pot . languages/${CIRCLE_PROJECT_REPONAME}.pot --exclude='src' --domain=${CIRCLE_PROJECT_REPONAME}
+        else
+          wp i18n make-pot . languages/${CIRCLE_PROJECT_REPONAME}.pot --domain=${CIRCLE_PROJECT_REPONAME}
+        fi
+  - run:
+      name: Create JSON translation files
+      command: |
+        sudo apt-get update && sudo apt-get install -y gettext
+        cd languages
+
+        # Create PO files from POT if they don't exist
+        if [ ! -f "${CIRCLE_PROJECT_REPONAME}-en_US.po" ]; then
+          wp i18n update-po ${CIRCLE_PROJECT_REPONAME}.pot .
+        fi
+
+        for po in ${CIRCLE_PROJECT_REPONAME}-*.po; do
+          if [ -f "$po" ]; then
+            # Update translations according to the new POT file
+            msgmerge $po $CIRCLE_PROJECT_REPONAME.pot -o $po.out
+            mv $po.out $po
+            msgfmt $po -o $(basename $po .po).mo
+            # no-purge since we need the JS translations for the next run
+            wp i18n make-json --no-purge $po .
+          fi
+        done
+  - run:
+      name: Commit translation files
+      command: |
+        LINES_CHANGED=$(git diff --numstat languages/ | awk '{sum += $1 + $2} END {print sum}')
+        # If no existing files were changed, check for new files
+        if [ -z "$LINES_CHANGED" ] || [ "$LINES_CHANGED" -eq 0 ]; then
+          LINES_CHANGED=$(git ls-files --others --exclude-standard languages/ | xargs wc -l 2>/dev/null | tail -1 | awk '{print $1}')
+        fi
+        LINES_CHANGED=${LINES_CHANGED:-0}
+        echo "Lines changed in languages/: $LINES_CHANGED"
+        if [ "$LINES_CHANGED" -gt 3 ]; then
+          git config user.email "$GITHUB_COMMITER_EMAIL"
+          git config user.name "$GIT_COMMITTER_NAME"
+          git remote set-url origin https://$GITHUB_TOKEN@github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git
+          git add languages/
+          git commit -m "chore: update translation files [skip ci]"
+          git push origin $CIRCLE_BRANCH
+        fi


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a `i18n` job to handle internationalization. This is released in version 1.5.7 of [the orb](https://circleci.com/developer/orbs/orb/newspack/newspack).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->