### PR TITLE
fix(release): only publish alpha and production releases to NPM

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -12,11 +12,7 @@ const filesList = files.split( ',' );
 
 utils.log( `Releasing ${ process.env.CIRCLE_PROJECT_REPONAME }…` );
 
-const shouldPublishOnNPM = Boolean( process.env.NPM_TOKEN );
-
-if ( shouldPublishOnNPM ) {
-	utils.log( `Will publish on npm` );
-}
+let shouldPublishOnNPM = Boolean( process.env.NPM_TOKEN );
 
 const getConfig = ({ gitBranchName }) => {
 	const branchType = gitBranchName.split("/")[0];
@@ -33,6 +29,12 @@ const getConfig = ({ gitBranchName }) => {
 	if ( ! ["alpha", "hotfix", "release"].includes(branchType) ) {
 		githubConfig.successComment = false;
 		githubConfig.failComment = false;
+	}
+
+	// Only publish alpha and release branches to NPM.
+	shouldPublishOnNPM = shouldPublishOnNPM && ["alpha", "release"].includes(branchType);
+	if ( shouldPublishOnNPM ) {
+		utils.log( `Will publish to npm.` );
 	}
 
 	const config = {

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -12,8 +12,6 @@ const filesList = files.split( ',' );
 
 utils.log( `Releasing ${ process.env.CIRCLE_PROJECT_REPONAME }…` );
 
-let shouldPublishOnNPM = Boolean( process.env.NPM_TOKEN );
-
 const getConfig = ({ gitBranchName }) => {
 	const branchType = gitBranchName.split("/")[0];
 	const githubConfig = {
@@ -32,7 +30,7 @@ const getConfig = ({ gitBranchName }) => {
 	}
 
 	// Only publish alpha and release branches to NPM.
-	shouldPublishOnNPM = shouldPublishOnNPM && ["alpha", "release"].includes(branchType);
+	const shouldPublishOnNPM = Boolean( process.env.NPM_TOKEN ) && ["alpha", "release"].includes(branchType);
 	if ( shouldPublishOnNPM ) {
 		utils.log( `Will publish to npm.` );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Our release CI job will currently publish any tagged release to NPM. This results in pretty messy versioning on NPM. This PR updates the release job to only publish to NPM if the release is an alpha or production release, going forward.

### How to test the changes in this Pull Request:

It won't be super easy to test this before it's merged and released to NPM itself, but after that, we can test by pushing a new `hotfix/*` or `epic/*` branchname to Newspack Blocks and confirming that the resulting tagged prerelease is NOT published to NPM, but new alpha or release tags ARE published.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
