### PR TITLE
refactor: reusable WP.org release workflow

### DIFF
--- a/.github/workflows/reusable-release-wporg.yml
+++ b/.github/workflows/reusable-release-wporg.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-          cache: npm
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci --legacy-peer-deps

--- a/.github/workflows/reusable-release-wporg.yml
+++ b/.github/workflows/reusable-release-wporg.yml
@@ -1,0 +1,58 @@
+# Release to WordPress.org.
+# Requires the calling workflow to run reusable-release.yml first (which uploads release artifacts).
+name: Release to WordPress.org
+
+on:
+  workflow_call:
+    inputs:
+      plugin-name:
+        description: 'WordPress.org plugin slug. Defaults to the repository name.'
+        required: false
+        type: string
+        default: ''
+    secrets:
+      WP_ORG_USERNAME:
+        required: true
+      WP_ORG_PASSWORD:
+        required: true
+
+jobs:
+  release-wporg:
+    name: Release to WordPress.org
+    runs-on: ubuntu-latest
+    env:
+      PLUGIN_NAME: ${{ inputs.plugin-name || github.event.repository.name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-artifacts
+          path: release/
+
+      - name: Verify release artifacts
+        run: |
+          if [ ! -d "release/$PLUGIN_NAME" ]; then
+            echo "::error::release/$PLUGIN_NAME not found. The release job must produce this directory via release:archive."
+            exit 1
+          fi
+
+      - name: Release to WordPress.org
+        env:
+          WP_ORG_USERNAME: ${{ secrets.WP_ORG_USERNAME }}
+          WP_ORG_PASSWORD: ${{ secrets.WP_ORG_PASSWORD }}
+          WP_ORG_PLUGIN_NAME: ${{ env.PLUGIN_NAME }}
+        run: ./node_modules/newspack-scripts/release-wporg.sh

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -51,3 +51,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm run release
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts
+          path: release/
+          if-no-files-found: ignore
+          retention-days: 1


### PR DESCRIPTION
The repos migrating from CircleCI to GitHub Actions that publish to WP.org had a `release-wporg` job that did a fresh checkout + `npm ci` but never built the `release/` directory that `release-wporg.sh` expects.

In CircleCI, this worked via `persist_to_workspace` / `attach_workspace`. This PR tries to bridge that gap using `upload-artifact` / `download-artifact`:

- Adds `reusable-release-wporg.yml`, a reusable workflow for publishing to WordPress.org that downloads release artifacts from the release job and runs `release-wporg.sh`.
- Accepts an optional `plugin-name` input (defaults to the repository name) for repos where the WP.org slug differs.
- Includes a guard step that fails with a clear error if the expected `release/<plugin-name>` directory is missing. For the existing cases, the repo names should match, but this could become useful in the future.
- Adds `retention-days: 1` to the release artifact upload in `reusable-release.yml`, since these artifacts are only needed as transitory glue between the release and WP.org release jobs within the same workflow run.

Consuming PRs:
- Automattic/newspack-newsletters#2021
- Automattic/super-cool-ad-inserter-plugin#237
- Automattic/republication-tracker-tool#298