### PR TITLE
fix(release-wporg): build release artifacts before uploading to WP.org

### DIFF
--- a/.github/workflows/reusable-release-wporg.yml
+++ b/.github/workflows/reusable-release-wporg.yml
@@ -38,7 +38,7 @@ jobs:
         run: npm ci --legacy-peer-deps
 
       - name: Build release artifacts
-        run: npm run release:archive
+        run: npm run build && npm run release:archive
 
       - name: Verify release artifacts
         run: |

--- a/.github/workflows/reusable-release-wporg.yml
+++ b/.github/workflows/reusable-release-wporg.yml
@@ -37,11 +37,8 @@ jobs:
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
 
-      - name: Download release artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: release-artifacts
-          path: release/
+      - name: Build release artifacts
+        run: npm run release:archive
 
       - name: Verify release artifacts
         run: |


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Instead of trying to fetch and download a release artifact built by a prior `release` job, just rebuilds the required artifact in the `release-org` job.

### How to test the changes in this Pull Request:

?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
