### PR TITLE
fix(release-wporg): only deploy stable version tags to WordPress.org

### DIFF
--- a/scripts/github/release-wporg.sh
+++ b/scripts/github/release-wporg.sh
@@ -11,7 +11,7 @@ SVN_PLUGINS_URL="https://plugins.svn.wordpress.org"
 SVN_REPO_LOCAL_PATH="release/svn"
 SVN_REPO_URL="$SVN_PLUGINS_URL/$WP_ORG_PLUGIN_NAME"
 
-LATEST_GIT_TAG=$(git tag --list 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+LATEST_GIT_TAG=$(git tag --list 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
 if [ -z "$LATEST_GIT_TAG" ]; then
   echo "No stable version tag found. Aborting deployment."
   exit 1

--- a/scripts/github/release-wporg.sh
+++ b/scripts/github/release-wporg.sh
@@ -11,7 +11,11 @@ SVN_PLUGINS_URL="https://plugins.svn.wordpress.org"
 SVN_REPO_LOCAL_PATH="release/svn"
 SVN_REPO_URL="$SVN_PLUGINS_URL/$WP_ORG_PLUGIN_NAME"
 
-LATEST_GIT_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+LATEST_GIT_TAG=$(git tag --list 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+if [ -z "$LATEST_GIT_TAG" ]; then
+  echo "No stable version tag found. Aborting deployment."
+  exit 1
+fi
 # Remove the "v" at the beginning of the git tag
 LATEST_SVN_TAG=${LATEST_GIT_TAG:1}
 


### PR DESCRIPTION
## Summary

Fixes [NPPM-2712](https://linear.app/a8c/issue/NPPM-2712)

- The WP.org deploy script used `git rev-list --tags --max-count=1` to find the latest tag, which searches **all tags across all branches** sorted by commit timestamp
- When a hotfix merged into `alpha` created a pre-release tag on a commit newer than the stable release commit, the script deployed the alpha version to WordPress.org
- Replace with `git tag --sort=-v:refname` filtered to stable version patterns only (`vX.Y.Z`), so pre-release tags (`-alpha`, `-hotfix-*`, `-epic-*`) are never selected

## Test plan

- [ ] Verify the tag selection logic works correctly by checking `git tag --list 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1` returns the latest stable tag in a repo with both stable and pre-release tags
- [ ] Confirm the next stable release of a plugin using this workflow deploys the correct version to WordPress.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)