### PR TITLE
fix(release): fail loudly when GitHub release asset is missing

### DIFF
--- a/scripts/github/release.js
+++ b/scripts/github/release.js
@@ -10,8 +10,17 @@ const { files, ...otherArgs } = require( 'yargs/yargs' )(
 
 const filesList = files.split( ',' );
 
-// Get repository name from GitHub Actions environment variable (format: owner/repo).
-const repoName = process.env.GITHUB_REPOSITORY?.split( '/' )[ 1 ] || 'unknown';
+if ( ! process.env.GITHUB_REPOSITORY ) {
+	console.error(
+		'GITHUB_REPOSITORY is not set. This script must run inside GitHub Actions ' +
+			'so the release asset path can be resolved. Aborting before semantic-release ' +
+			'publishes a release without an attached ZIP.'
+	);
+	process.exit( 1 );
+}
+
+const repoName = process.env.GITHUB_REPOSITORY.split( '/' )[ 1 ];
+const releaseAssetPath = `./release/${ repoName }.zip`;
 
 utils.log( `Releasing ${ repoName }…` );
 
@@ -20,7 +29,7 @@ const getConfig = ({ gitBranchName }) => {
 	const githubConfig = {
 		assets: [
 			{
-				path: `./release/${ repoName }.zip`,
+				path: releaseAssetPath,
 				label: `${ repoName }.zip`,
 			},
 		],
@@ -96,6 +105,11 @@ const getConfig = ({ gitBranchName }) => {
 			callback: 'npm run release:archive',
 		},
 	] );
+
+	// Verify the release archive exists on disk after `release:archive` ran.
+	// `@semantic-release/github` silently ignores missing assets, so without this
+	// guard a misconfigured archive step would publish a release with no ZIP.
+	config.prepare.push( require.resolve( './verify-release-asset.js' ) );
 
 	// Unless on a hotfix or epic branch, add a commit that updates the files.
 	if ( [ 'hotfix', 'epic' ].indexOf( branchType ) === -1 ) {

--- a/scripts/github/release.js
+++ b/scripts/github/release.js
@@ -19,7 +19,15 @@ if ( ! process.env.GITHUB_REPOSITORY ) {
 	process.exit( 1 );
 }
 
-const repoName = process.env.GITHUB_REPOSITORY.split( '/' )[ 1 ];
+const [ repoOwner, repoName ] = process.env.GITHUB_REPOSITORY.split( '/' );
+if ( ! repoOwner || ! repoName ) {
+	console.error(
+		`GITHUB_REPOSITORY must be in "owner/repo" format; received "${ process.env.GITHUB_REPOSITORY }". ` +
+			'Aborting before semantic-release publishes a release with an invalid asset path.'
+	);
+	process.exit( 1 );
+}
+
 const releaseAssetPath = `./release/${ repoName }.zip`;
 
 utils.log( `Releasing ${ repoName }…` );

--- a/scripts/github/verify-release-asset.js
+++ b/scripts/github/verify-release-asset.js
@@ -3,6 +3,8 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
 
+const utils = require( '../utils/index.js' );
+
 const repoName = process.env.GITHUB_REPOSITORY?.split( '/' )[ 1 ];
 const releaseAssetPath = path.resolve( `./release/${ repoName }.zip` );
 
@@ -19,7 +21,7 @@ async function prepare() {
 				'semantic-release publishes the GitHub release.'
 		);
 	}
-	console.log( `[verify-release-asset] OK: ${ releaseAssetPath }` );
+	utils.log( `Verified release asset at ${ releaseAssetPath }.` );
 }
 
 module.exports = { prepare };

--- a/scripts/github/verify-release-asset.js
+++ b/scripts/github/verify-release-asset.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+const repoName = process.env.GITHUB_REPOSITORY?.split( '/' )[ 1 ];
+const releaseAssetPath = path.resolve( `./release/${ repoName }.zip` );
+
+async function prepare() {
+	if ( ! repoName ) {
+		throw new Error(
+			'GITHUB_REPOSITORY is not set; cannot determine release asset path.'
+		);
+	}
+	if ( ! fs.existsSync( releaseAssetPath ) ) {
+		throw new Error(
+			`Release asset not found at ${ releaseAssetPath }. ` +
+				'The `release:archive` script must produce this file before ' +
+				'semantic-release publishes the GitHub release.'
+		);
+	}
+	console.log( `[verify-release-asset] OK: ${ releaseAssetPath }` );
+}
+
+module.exports = { prepare };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`@semantic-release/github` silently ignores release assets whose path cannot be read on disk – it emits a single warning and then publishes the GitHub release anyway, with no attached archive. This is exactly what happened to `newspack-ads` v3.10.2: the legacy `scripts/release.js` interpolated `process.env.CIRCLE_PROJECT_REPONAME` to `undefined` under GitHub Actions, the asset path resolved to `./release/undefined.zip`, the file did not exist, and the v3.10.2 release shipped without a ZIP. The bug was only noticed after the release was already public.

This PR closes that failure mode in `scripts/github/release.js` so a similar misconfiguration cannot silently produce an asset-less release again:

- The script now hard-fails at startup if `GITHUB_REPOSITORY` is unset, rather than falling back to the placeholder string `'unknown'` and producing an `unknown.zip` asset path that will never match anything on disk.
- A new local plugin (`scripts/github/verify-release-asset.js`) is appended to the `prepare` lifecycle. It runs after `release:archive` is invoked by `semantic-release-version-bump` and throws if the expected `./release/<repo>.zip` is not present. Because it throws during `prepare`, semantic-release aborts the run before the `publish` lifecycle, so no GitHub release is created without the asset attached.

The behavior on a successful release is unchanged – the verification plugin just logs an `OK` line when the file is present.

Closes NPPM-2744.

### How to test the changes in this Pull Request:

The most realistic verification is a dry-run release in a consumer plugin. Using `newspack-ads` (or any plugin that consumes `newspack-scripts` via the reusable workflow) on a throwaway branch:

1. Point the consumer's `newspack-scripts` dependency at this branch (`github:Automattic/newspack-scripts#fix/release-fail-on-missing-asset`) and run `npm install`.
2. **Happy path** – Run the release flow end-to-end (e.g. trigger the `release` workflow on a test branch, or run `npm run release` locally with `GITHUB_ACTIONS=true GITHUB_REPOSITORY=Automattic/newspack-ads` set and a valid token). Confirm the new log line `[verify-release-asset] OK: …/release/newspack-ads.zip` appears and the GitHub release is published with the ZIP attached, exactly as before.
3. **Missing-asset path** – Temporarily break the consumer's `release:archive` script (e.g. point its output at a different filename, or comment out the `zip` line). Re-run the release. Confirm semantic-release aborts during `prepare` with the error `Release asset not found at …/release/<repo>.zip` and that **no GitHub release tag is created**. This is the regression we are guarding against.
4. **Missing `GITHUB_REPOSITORY`** – Run `node scripts/github/release.js --files=newspack-ads.php` with `GITHUB_REPOSITORY` unset. Confirm it exits with code 1 and prints the `GITHUB_REPOSITORY is not set` message before semantic-release is even constructed.
5. Verify nothing changes for non-GitHub-Actions consumers: `bin/newspack-scripts.js` only routes to `scripts/github/release.js` when `GITHUB_ACTIONS=true`, so the legacy `scripts/release.js` code path is untouched.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?