### PR TITLE
fix(i18n): drop skip-ci marker from bot commit message

### DIFF
--- a/.github/workflows/reusable-i18n.yml
+++ b/.github/workflows/reusable-i18n.yml
@@ -134,6 +134,13 @@ jobs:
           echo "Lines changed in languages/: $LINES_CHANGED"
           if [ "$LINES_CHANGED" -gt 3 ]; then
             git add languages/
-            git commit -m "chore: update translation files [skip ci]"
+            # No [skip ci] marker: the committer-email check above prevents
+            # this workflow from running on its own commits, and consumer
+            # repos should path-filter their other push-triggered workflows
+            # (paths-ignore: languages/**) to avoid wasting CI on
+            # translation-only updates. The marker was previously leaking
+            # into release-merge commit bodies via GitHub's auto-populated
+            # bullet list and silently killing the Release workflow.
+            git commit -m "chore: update translation files"
             git push
           fi


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Drops the `[skip ci]` marker from the translation-update commit subject in `.github/workflows/reusable-i18n.yml`. Adds a comment explaining why.

**Why:** the marker has a leak path that silently kills releases. When a consumer repo merges trunk into release with a custom merge commit title (e.g. "Release May 13"), GitHub's UI auto-populates the merge commit body with a bulleted list of the constituent commits — including the verbatim `[skip ci]` subjects from this workflow. GitHub Actions scans the **entire** commit message (subject + body) for skip directives and skips the entire push when it finds one — including the consumer's `Release` workflow.

This just bit `newspack-manager-admin#441`: zero workflow runs were created on the release-merge commit, no release ran. Recovery required pushing an empty commit on `release`. Investigation: https://github.com/Automattic/newspack-manager-admin/pull/441 → https://github.com/Automattic/newspack-manager-admin/pull/442

**Why dropping the marker is safe here:** the recursion guard inside this workflow already prevents it from running on its own commits — see the "Check if commit author is bot" step at the top of the job, which short-circuits via `steps.check-bot.outputs.skip`. The `[skip ci]` was redundant defense-in-depth that turned out to be actively harmful in the merge-body leak scenario.

**Small cost trade-off to be aware of:** the two recursion guards are not 100% equivalent. With `[skip ci]`, the workflow is *not triggered at all* when the bot's commit lands — zero runner minutes. With the committer-email check alone, the workflow *is* triggered, spins up a runner, checks out the repo, configures Node/git, and then short-circuits at the "Check if commit author is bot" step. That's a small overhead (a minute or so per translation commit on trunk) that we'd pay in exchange for closing the merge-body leak. Worth it, but not free.

**Migration for consumer repos:** repos that depend on `[skip ci]` to keep their *other* push-triggered workflows (`build-and-test.yml`, `php.yml`, etc.) from running on translation-only pushes should add `paths-ignore: ['languages/**']` to those workflows' `push` triggers. That's a more precise mechanism that can't leak through merges. Done for `newspack-manager-admin` in [PR #442](https://github.com/Automattic/newspack-manager-admin/pull/442) and for `newspack-workspace` in [PR #88](https://github.com/Automattic/newspack-workspace/pull/88); the rest of the consumer repos will need similar fixes — happy to file them if this approach is approved.

**Draft because:** I'd like sign-off on the approach (drop the marker org-wide vs. some other mitigation) before opening it for review. Specifically, this change affects every repo that uses `reusable-i18n.yml@trunk`, so anyone who currently relies on `[skip ci]` (rather than the committer-email guard) to keep their CI quiet would suddenly start running builds on translation pushes until they add a `paths-ignore` filter.

### How to test the changes in this Pull Request:

1. Merge this PR.
2. Wait for the next i18n bot run on any consumer repo (e.g. `newspack-plugin`'s trunk).
3. Verify the bot's commit lands without `[skip ci]` in the subject.
4. Verify the bot's commit DOES trigger the i18n workflow this time (since the marker is gone) but the workflow short-circuits at the committer-email check — i.e. the run completes quickly and as a no-op.
5. Verify that consumer repos that have added `paths-ignore: languages/**` (e.g. newspack-manager-admin once #442 merges) don't run Build/PHP on the bot's commit.
6. Verify that the next release-merge in any consumer repo triggers the Release workflow regardless of the merge commit body content.

### Other information:

- This is a behavior change for every repo using `reusable-i18n.yml`. Per-repo rollout of `paths-ignore` may need to happen alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)